### PR TITLE
Pad computation results to the required length.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,6 +51,7 @@ use rsa::{
     BigUint, PaddingScheme, PublicKey as _, PublicKeyParts as _, RsaPrivateKey, RsaPublicKey,
 };
 use std::fmt::{self, Display};
+use std::iter;
 
 pub mod reexports {
     pub use {digest, hmac_sha512, rand, rsa};
@@ -237,6 +238,24 @@ fn emsa_pss_encode(
     Ok(em)
 }
 
+/// Pad `v` with leading zeroes up to the desired length.
+///
+/// This function can be used to left-pad the big-endian representation of a `BigUint` to a certain
+/// length. More specifically, when converting a vector of bytes to `BigUint` and applying some
+/// transformations, calling `to_bytes_be()` can unexpectedly result in a vector of bytes of a
+/// different length (because `to_bytes_be()` discards any leading zeroes). See this issue for more
+/// details: https://github.com/rust-num/num-bigint/issues/201
+fn zero_left_pad(v: Vec<u8>, len: usize) -> Vec<u8> {
+    if len > v.len() {
+        iter::repeat(0)
+            .take(len - v.len())
+            .chain(v.into_iter())
+            .collect()
+    } else {
+        v
+    }
+}
+
 impl PublicKey {
     pub fn to_der(&self) -> Result<Vec<u8>, Error> {
         self.as_ref()
@@ -319,9 +338,11 @@ impl PublicKey {
         let m = BigUint::from_bytes_be(&padded);
 
         let (blind_msg, secret) = rsa_internals::blind(&mut rng, self.as_ref(), &m);
+        let secret = secret.to_bytes_be();
+        let blind_msg = blind_msg.to_bytes_be();
         Ok(BlindingResult {
-            blind_msg: BlindedMessage(blind_msg.to_bytes_be()),
-            secret: Secret(secret.to_bytes_be()),
+            blind_msg: BlindedMessage(zero_left_pad(blind_msg, modulus_bytes)),
+            secret: Secret(zero_left_pad(secret, modulus_bytes)),
         })
     }
 
@@ -339,8 +360,8 @@ impl PublicKey {
         }
         let blind_sig = BigUint::from_bytes_be(blind_sig);
         let secret = BigUint::from_bytes_be(secret);
-        let sig =
-            Signature(rsa_internals::unblind(self.as_ref(), &blind_sig, &secret).to_bytes_be());
+        let sig = rsa_internals::unblind(self.as_ref(), &blind_sig, &secret).to_bytes_be();
+        let sig = Signature(zero_left_pad(sig, modulus_bytes));
         self.verify(&sig, msg, options)?;
         Ok(sig)
     }
@@ -432,7 +453,8 @@ impl SecretKey {
             return Err(Error::UnsupportedParameters);
         }
         let blind_sig = rsa_internals::decrypt_and_check(Some(&mut rng), self.as_ref(), &blind_msg)
-            .map_err(|_| Error::InternalError)?;
-        Ok(BlindSignature(blind_sig.to_bytes_be()))
+            .map_err(|_| Error::InternalError)?
+            .to_bytes_be();
+        Ok(BlindSignature(zero_left_pad(blind_sig, modulus_bytes)))
     }
 }

--- a/src/num_padding.rs
+++ b/src/num_padding.rs
@@ -1,0 +1,25 @@
+use rsa::BigUint;
+use std::iter;
+
+pub trait ToBytesPadded {
+    /// Returns the byte representation of `self` in big-endian byte order, left-padding the number
+    /// with zeroes to the specified length.
+    ///
+    /// If `len` is less than or equal to the length of the byte representation of `self`, no
+    /// padding will be added.
+    fn to_bytes_be_padded(&self, len: usize) -> Vec<u8>;
+}
+
+impl ToBytesPadded for BigUint {
+    fn to_bytes_be_padded(&self, len: usize) -> Vec<u8> {
+        let v = self.to_bytes_be();
+        if len > v.len() {
+            iter::repeat(0)
+                .take(len - v.len())
+                .chain(v.into_iter())
+                .collect()
+        } else {
+            v
+        }
+    }
+}


### PR DESCRIPTION
I noticed `pk.finalize()` occasionally (and for no apparent reason) returns an
`UnsupportedParameters` error, instead of the `Ok` result I would expect.

I don't have a minimal reproducible example I can share yet, but here are the
steps I took to reproduce the issue:
* use `pk.blind()` to create a blinded message for a recipient whose public key
is `pk`
* get the recipient to produce a blinded signature and use it to create a
`BlindedSignature`
* call `pk.finalize(...)` <--- this will occasionally fail the verification:
   * first the message is unblinded to produce the signature of the original
   message: https://github.com/jedisct1/rust-blind-rsa-signatures/blob/622b6a5949544a35c9d5913ddb599a7fe6de5cfa/src/lib.rs#L342-L344
   * the signature then fails the verification because `sig.len() != modulus_bytes`
   (in my case, `sig.len() = 511` and `modulus_bytes = 512`): https://github.com/jedisct1/rust-blind-rsa-signatures/blob/622b6a5949544a35c9d5913ddb599a7fe6de5cfa/src/lib.rs#L357-L359

This is what I think happens:
* [these initial checks] pass, so I know `blind_sig.len() == modulus_bytes`
* according to the RFC, the resulting unblinded signature should have [the same
length] as the blinded signature
* somehow [this other length check] fails, despite the fact that
`blind_sig.len() == modulus_bytes` at the beginning of `finalize()`!
* the problem seems to be this: converting a vector of bytes to and
from`BigUint`, with some transformations in between (i.e. `unblind`), doesn't
guarantee the output vector has the same length as the input one, because
`BigUint` will strip away any leading zeroes from the representation of the
number:
https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=80d02761702f676119fedbb9a5ddd845

This patch fixes the problem for me (the solution seems to be to pad any vectors
obtained using `to_bytes_be` to have a length of `modulus_bytes`).

[these initial checks]: https://github.com/jedisct1/rust-blind-rsa-signatures/blob/622b6a5949544a35c9d5913ddb599a7fe6de5cfa/src/lib.rs#L337-L339
[the same length]: https://cfrg.github.io/draft-irtf-cfrg-blind-signatures/draft-irtf-cfrg-rsa-blind-signatures.html#name-finalize
[this other length check]: https://github.com/jedisct1/rust-blind-rsa-signatures/blob/622b6a5949544a35c9d5913ddb599a7fe6de5cfa/src/lib.rs#L357-L359