### PR TITLE
External rng

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blind-rsa-signatures"
-version = "0.14.0"
+version = "0.15.0"
 authors = ["Frank Denis <github@pureftpd.org>"]
 edition = "2018"
 description = "RSA blind signatures in pure Rust"

--- a/README.md
+++ b/README.md
@@ -31,19 +31,20 @@ The scheme was designed by David Chaum, and was originally implemented for anony
 ```rust
 use blind_rsa_signatures::{KeyPair, Options};
 let options = Options::default();
+let rng = &mut rand::thread_rng();
 
 // [SERVER]: Generate a RSA-2048 key pair
-let kp = KeyPair::generate(2048)?;
+let kp = KeyPair::generate(rng, 2048)?;
 let (pk, sk) = (kp.pk, kp.sk);
 
 // [CLIENT]: create a random message and blind it for the server whose public key is `pk`.
 // The client must store the message and the secret.
 let msg = b"test";
-let blinding_result = pk.blind(msg, true, &options)?;
+let blinding_result = pk.blind(rng, msg, true, &options)?;
 
 // [SERVER]: compute a signature for a blind message, to be sent to the client.
 // The client secret should not be sent to the server.
-let blind_sig = sk.blind_sign(&blinding_result.blind_msg, &options)?;
+let blind_sig = sk.blind_sign(rng, &blinding_result.blind_msg, &options)?;
 
 // [CLIENT]: later, when the client wants to redeem a signed blind message,
 // using the blinding secret, it can locally compute the signature of the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 //! let rng = &mut rand::thread_rng();
 //!
 //! // [SERVER]: Generate a RSA-2048 key pair
-//! let kp = KeyPair::generate(2048)?;
+//! let kp = KeyPair::generate(rng, 2048)?;
 //! let (pk, sk) = (kp.pk, kp.sk);
 //!
 //! // [CLIENT]: create a random message and blind it for the server whose public key is `pk`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,10 +203,12 @@ impl AsRef<[u8]> for Signature {
 
 impl KeyPair {
     /// Generate a new key pair
-    pub fn generate(modulus_bits: usize) -> Result<KeyPair, Error> {
-        let mut rng = rand::thread_rng();
+    pub fn generate<R: CryptoRng + RngCore>(
+        rng: &mut R,
+        modulus_bits: usize,
+    ) -> Result<KeyPair, Error> {
         let mut sk =
-            RsaPrivateKey::new(&mut rng, modulus_bits).map_err(|_| Error::UnsupportedParameters)?;
+            RsaPrivateKey::new(rng, modulus_bits).map_err(|_| Error::UnsupportedParameters)?;
         sk.precompute().map_err(|_| Error::InternalError)?;
         let sk = SecretKey(sk);
         let pk = sk.public_key()?;


### PR DESCRIPTION
Makes `blind()` and `blind_sign()` accept an external RNG. This would be helpful for applications that require a dedicated RNG.