### PR TITLE
Add serde Deserialize and Serialize derives

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ hmac-sha256 = { version = "1.1.7", features = ["traits010"] }
 hmac-sha512 = { version = "1.1.5", features = ["traits010", "sha384"] }
 derive-new = "0.5.9"
 derive_more = "0.99.17"
-serde = {version = "1.0.203", features = ["derive"], optional = true }
+serde = {version = "1", features = ["derive"], optional = true }
 
 [dev-dependencies]
 criterion = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,8 @@ serde = {version = "1.0.203", features = ["derive"], optional = true }
 criterion = "0.5"
 
 [features]
-serde = ["dep:serde"]
+default = ["serde"]
+serde = ["dep:serde", "rsa/serde"]
 
 [[bench]]
 name = "speed_test"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,9 +21,13 @@ hmac-sha256 = { version = "1.1.7", features = ["traits010"] }
 hmac-sha512 = { version = "1.1.5", features = ["traits010", "sha384"] }
 derive-new = "0.5.9"
 derive_more = "0.99.17"
+serde = {version = "1.0.203", features = ["derive"], optional = true }
 
 [dev-dependencies]
 criterion = "0.5"
+
+[features]
+serde = ["dep:serde"]
 
 [[bench]]
 name = "speed_test"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,10 +140,12 @@ impl Options {
 }
 
 /// An RSA public key
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, Eq, PartialEq, AsRef, Deref, From, Into, new)]
 pub struct PublicKey(pub RsaPublicKey);
 
 /// An RSA secret key
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, AsRef, Deref, From, Into, new)]
 pub struct SecretKey(pub RsaPrivateKey);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,9 @@ use rsa::pkcs8::{
 use rsa::signature::hazmat::PrehashVerifier;
 use rsa::{BigUint, PublicKeyParts as _, RsaPrivateKey, RsaPublicKey};
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 pub mod reexports {
     pub use {digest, hmac_sha512, rand, rsa};
 }
@@ -156,14 +159,17 @@ pub struct KeyPair {
 pub struct Secret(pub Vec<u8>);
 
 /// A blinded message
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, AsRef, Deref, From, Into, new)]
 pub struct BlindedMessage(pub Vec<u8>);
 
 /// A blind signature
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, AsRef, Deref, From, Into, new)]
 pub struct BlindSignature(pub Vec<u8>);
 
 /// A (non-blind) signature
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, AsRef, Deref, From, Into, new)]
 pub struct Signature(pub Vec<u8>);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,6 +174,7 @@ pub struct BlindSignature(pub Vec<u8>);
 pub struct Signature(pub Vec<u8>);
 
 /// A message randomizer (noise added as a prefix to the message)
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Copy, Debug, AsRef, Deref, From, Into, new)]
 pub struct MessageRandomizer(pub [u8; 32]);
 


### PR DESCRIPTION
I only added these on the types which, in my use case, are shared over the wire. They seem to be the most likely types in general to be shared in a blind signature scheme. This is all behind a `serde` feature flag (including the dependency).

Thank you for this great crate!