### PR TITLE
Allow &mut dyn CryptoRng to be passed in

### DIFF
--- a/src/blind_rsa.rs
+++ b/src/blind_rsa.rs
@@ -1,5 +1,5 @@
 use crypto_bigint::{BoxedUint, NonZero, RandomMod};
-use rsa::rand_core::{CryptoRng, RngCore};
+use rsa::rand_core::CryptoRng;
 use rsa::traits::{PrivateKeyParts, PublicKeyParts};
 
 /// Blinds a message using the server's public key and a random factor.
@@ -13,7 +13,7 @@ use rsa::traits::{PrivateKeyParts, PublicKeyParts};
 /// # Returns
 ///
 /// A tuple containing the blinded message and the secret factor
-pub fn blind<R: CryptoRng + RngCore, K: PublicKeyParts>(
+pub fn blind<R: CryptoRng + ?Sized, K: PublicKeyParts>(
     rng: &mut R,
     key: &K,
     c: &BoxedUint,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@ use rsa::pkcs1::{DecodeRsaPrivateKey as _, DecodeRsaPublicKey as _};
 use rsa::pkcs8::{
     DecodePrivateKey as _, DecodePublicKey as _, EncodePrivateKey as _, EncodePublicKey as _,
 };
-use rsa::rand_core::{CryptoRng, RngCore, TryCryptoRng, TryRngCore};
+use rsa::rand_core::{CryptoRng, TryCryptoRng, TryRngCore};
 use rsa::signature::hazmat::PrehashVerifier;
 use rsa::traits::PublicKeyParts as _;
 use rsa::{RsaPrivateKey, RsaPublicKey};
@@ -315,7 +315,7 @@ impl AsRef<[u8]> for Error {
 
 impl KeyPair {
     /// Generate a new key pair
-    pub fn generate<R: CryptoRng + RngCore>(
+    pub fn generate<R: CryptoRng + ?Sized>(
         rng: &mut R,
         modulus_bits: usize,
     ) -> Result<KeyPair, Error> {
@@ -571,7 +571,7 @@ impl PublicKey {
     }
 
     /// Blind a message (after optional randomization) to be signed
-    pub fn blind<R: CryptoRng + RngCore>(
+    pub fn blind<R: CryptoRng + ?Sized>(
         &self,
         rng: &mut R,
         msg: impl AsRef<[u8]>,


### PR DESCRIPTION
CryptoRng implies RngCore so that bound is not necessary, and by not requiring R to be sized it can be `dyn CryptoRng`