### PR TITLE
Make Options fields public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -161,11 +161,11 @@ pub enum PrepareMode {
 #[derive(Clone, Debug, Eq, PartialEq, AsRef, From, Into, new)]
 pub struct Options {
     /// Hash function to use for padding and for hashing the message
-    hash: Hash,
+    pub hash: Hash,
     /// Either `PSSMode::PSS` to use salt, or `PSSMode::PSSZero` for empty salt
-    pss_mode: PSSMode,
+    pub pss_mode: PSSMode,
     /// Use deterministic or randomized message padding
-    prepare: PrepareMode,
+    pub prepare: PrepareMode,
 }
 
 impl Default for Options {


### PR DESCRIPTION
I find myself writing this a lot
```rs
let options = {
  let (hash, pss, _) = Options::default().into();
  Options::new(hash, pss, PrepareMode::Deterministic)
};
```
which would be a lot more clear and idiomatic if I wrote
```rs
let options = Options {
  prepare_mode: PrepareMode::Deterministic,
  ...Default::default()
};
```


Another related but subtle question I have is: should the default be `Deterministic`? I think users of this lib will be quite surprised when upgrading to the new version that `Options::default()` has "opposite" different semantics now